### PR TITLE
Remove unnecessary InstanceMethods module

### DIFF
--- a/lib/fastly-rails/action_controller/surrogate_control_headers.rb
+++ b/lib/fastly-rails/action_controller/surrogate_control_headers.rb
@@ -1,15 +1,10 @@
 module FastlyRails
   module SurrogateControlHeaders
-    extend ActiveSupport::Concern
-
-    included do
-    end
-
     # Sets Surrogate-Control header
     # Defaults are:
     #  Cache-Control: 'public, no-cache, s-maxage: 30 days'
     #  Surrogate-Control: 'max-age: 30 days
-    # custom config example: 
+    # custom config example:
     #  {cache_control: 'blah, blah, blah', surrogate_control: 'max-age: blah'}
     def set_surrogate_key_header(surrogate_key)
       request.session_options[:skip] = true    # no cookies

--- a/lib/fastly-rails/active_record/surrogate_key.rb
+++ b/lib/fastly-rails/active_record/surrogate_key.rb
@@ -3,10 +3,6 @@ module FastlyRails
   module SurrogateKey
     extend ActiveSupport::Concern
 
-    included do
-      include InstanceMethods
-    end
-
     module ClassMethods
 
       def purge_all
@@ -19,24 +15,20 @@ module FastlyRails
 
     end
 
-    module InstanceMethods
+    def record_key
+      "#{table_key}/#{id}"
+    end
 
-      def record_key
-        "#{table_key}/#{id}"
-      end
+    def table_key
+      self.class.table_key
+    end
 
-      def table_key
-        self.class.table_key
-      end
+    def purge
+      FastlyRails.client.purge(record_key)
+    end
 
-      def purge
-        FastlyRails.client.purge(record_key)
-      end
-
-      def purge_all
-        self.class.purge_all
-      end
-
+    def purge_all
+      self.class.purge_all
     end
 
   end


### PR DESCRIPTION
Stack Overflow has a good explanation of why the InstanceMethods module is
overkill:
http://stackoverflow.com/questions/8706897/why-has-the-instancemethods-module-been-deprecated
