### PR TITLE
Use `self.method` instead of `extend self`

### DIFF
--- a/lib/fastly-rails.rb
+++ b/lib/fastly-rails.rb
@@ -7,23 +7,22 @@ module FastlyRails
 
   attr_reader :client, :configuration
 
-  def configuration
+  def self.configuration
     @configuration ||= Configuration.new
   end
 
-  def configure
+  def self.configure
     yield configuration if block_given?
   end
 
-  def client
-      raise NoAuthCredentialsProvidedError unless configuration.authenticatable?
-      @client ||= Client.new(
-        :api_key  => configuration.api_key,
-        :user     => configuration.user,
-        :password => configuration.password,
-      )
-  end
+  def self.client
+    raise NoAuthCredentialsProvidedError unless configuration.authenticatable?
 
-  extend self
+    @client ||= Client.new(
+      :api_key  => configuration.api_key,
+      :user     => configuration.user,
+      :password => configuration.password,
+    )
+  end
 
 end


### PR DESCRIPTION
This is just my opinion, but I find `extend self` surprising because it means I have to go back and re-read all of the methods, now knowing that they're class methods and not instance methods.
