### PR TITLE
Adding webmock to gems for local testing

### DIFF
--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ffaker"
   s.add_development_dependency "minitest-spec-rails"
   s.add_development_dependency "appraisal"
+  s.add_development_dependency "webmock"
 end


### PR DESCRIPTION
I tried running tests locally, and got the following error trace:

```
~ rake
$:.push File.expand_path("../lib", __FILE__)
/Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/activesupport-4.1.2.rc1/lib/active_support/dependencies.rb:247:in `require': cannot load such file -- webmock/minitest (LoadError)
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/activesupport-4.1.2.rc1/lib/active_support/dependencies.rb:247:in `block in require'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/activesupport-4.1.2.rc1/lib/active_support/dependencies.rb:232:in `load_dependency'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/activesupport-4.1.2.rc1/lib/active_support/dependencies.rb:247:in `require'
    from /Users/aspires/fastly/fastly-rails/test/test_helper.rb:10:in `<top (required)>'
$:.push File.expand_path("../lib", __FILE__)
    from /Users/aspires/fastly/fastly-rails/test/dummy/test/controllers/books_controller_test.rb:1:in `require'
    from /Users/aspires/fastly/fastly-rails/test/dummy/test/controllers/books_controller_test.rb:1:in `<top (required)>'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:10:in `require'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:9:in `each'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:9:in `block in <main>'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib:lib:test" -I"/Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib" "/Users/aspires/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" ]
```

Adding `webmock` to the gem dependencies corrected this. On a side note, the tests pass on ruby 2.0.0-p247
