### PR TITLE
ensure configuration test never fails due to randomization

### DIFF
--- a/test/fastly-rails_test.rb
+++ b/test/fastly-rails_test.rb
@@ -16,6 +16,10 @@ describe FastlyRails do
 
   describe 'credentials not provided' do
 
+    before do
+      FastlyRails.instance_variable_set('@configuration', FastlyRails::Configuration.new)
+    end
+
     it 'should raise an error if configuration is not authenticatable' do
 
       assert_equal false, configuration.authenticatable?


### PR DESCRIPTION
- since these tests can run in random order, we need to ensure configuration is reset for that nil-configuration test.
