### PR TITLE
Index action should join resource keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ source "https://rubygems.org"
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec
-

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ class BooksController < ApplicationController
 
   def index
     @books = Book.all
-    set_surrogate_key_header @book.table_key
+    set_surrogate_key_header 'books', @books.map(&:record_key)
   end
 
   def show

--- a/lib/fastly-rails/action_controller/surrogate_control_headers.rb
+++ b/lib/fastly-rails/action_controller/surrogate_control_headers.rb
@@ -6,10 +6,9 @@ module FastlyRails
     #  Surrogate-Control: 'max-age: 30 days
     # custom config example:
     #  {cache_control: 'blah, blah, blah', surrogate_control: 'max-age: blah'}
-    def set_surrogate_key_header(surrogate_key)
+    def set_surrogate_key_header(*surrogate_keys)
       request.session_options[:skip] = true    # no cookies
-      response.headers['Surrogate-Key'] = surrogate_key
+      response.headers['Surrogate-Key'] = surrogate_keys.join(' ')
     end
-
   end
 end

--- a/test/dummy/app/controllers/books_controller.rb
+++ b/test/dummy/app/controllers/books_controller.rb
@@ -1,13 +1,14 @@
 class BooksController < ApplicationController
-
   before_filter :set_cache_control_headers, only: [:index, :show]
   before_filter :find_book, :only => [:show, :edit, :update, :destroy]
 
   def index
     @books = Book.all
+    set_surrogate_key_header 'books', @books.map(&:record_key)
   end
 
   def show
+    set_surrogate_key_header @book.record_key
   end
 
   def new

--- a/test/dummy/test/controllers/books_controller_test.rb
+++ b/test/dummy/test/controllers/books_controller_test.rb
@@ -11,12 +11,19 @@ class BooksControllerTest < ActionController::TestCase
     )
     @no_of_books = 5
     create_list :book, @no_of_books
-    end
+  end
 
   test "index" do
     get :index
     assert_response :success, 'it should return successfully'
     assert_equal @no_of_books, assigns(:books).count, "it should retrieve #{@no_of_books} books"
+  end
+
+  test "index with multiple params" do
+    get :index
+    expected_surrogate_keys = 'books books/1 books/2 books/3 books/4 books/5'
+
+    assert_equal expected_surrogate_keys, response.headers['Surrogate-Key'], 'surrogate keys returned'
   end
 
   test "show" do
@@ -26,6 +33,7 @@ class BooksControllerTest < ActionController::TestCase
     assert_not_nil assigns(:book), '@book should not be nil'
     assert_instance_of Book, assigns(:book), 'it should be an instance of a book'
     assert_equal expected_id, assigns(:book).id, 'book.id should be the expected id'
+    assert_equal "books/#{expected_id}", response.headers['Surrogate-Key'], "surrogate key for book"
   end
 
   test "create" do
@@ -34,5 +42,4 @@ class BooksControllerTest < ActionController::TestCase
       post :create, :book => {'name' => expected_name}
     end
   end
-
 end

--- a/test/dummy/test/integration/fastly_headers_test.rb
+++ b/test/dummy/test/integration/fastly_headers_test.rb
@@ -67,11 +67,9 @@ class FastlyHeadersTest < ActionDispatch::IntegrationTest
     assert_equal 'no-cache', response.headers['Cache-Control']
 
     assert !response.headers.key?('Surrogate-Control')
-
   end
 
   test 'DELETE /books/:id should not have fastly headers/ fastly header values' do
-
     create :book, :id => 1
 
     delete '/books/1'
@@ -84,8 +82,5 @@ class FastlyHeadersTest < ActionDispatch::IntegrationTest
     assert_equal 'no-cache', response.headers['Cache-Control']
 
     assert !response.headers.key?('Surrogate-Control')
-
   end
-
 end
-


### PR DESCRIPTION
- Example in README used undefined instance variable
- This change makes `set_surrogate_key_header` implementation consistent with
  http://www.hward.com/varnish-cache-invalidation-with-fastly-surrogate-keys
