### PR TITLE
Add optional middleware for removing `Set-Cookie`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ class BooksController < ApplicationController
 end
 ````
 
+### [Optional] Removing `Set-Cookie` headers
+
+The `set_cache_control_headers` method removes the `Set-Cookie` header from a
+request. In some cases, other libraries will have middleware that inserts a
+`Set-Cookie` header into your request *after* fastly-rails removes it. This is
+problematic because Fastly will not cache any pages with a `Set-Cookie` header.
+
+In order to remove the `Set-Cookie` header, fastly-rails provides an optional
+piece of middleware that removes `Set-Cookie` when the `Surrogate-Control`
+header is present (the `Surrogate-Control` header is also inserted by the
+`set_cache_control_headers` method and indicates that you want the endpoint to
+be cached by Fastly and do not need cookies).
+
+To override a piece of middleware in Rails, you must insert middleware before
+it. Once you've identified which middleware is inserting the `Set-Cookie`
+header, add the following (in this example, `ExampleMiddleware` is what we are
+trying to override`:
+
+```ruby
+# config/application.rb
+
+  config.middleware.insert_before(
+    ExampleMiddleware,
+    "FastlyRails::Rack::RemoveSetCookieHeader"
+  )
+```
+
 ### Purges
 
 Any object that inherits from ActiveRecord will have `purge_all` and `table_key` class methods available as well as `purge` and `purge_all` instance methods.

--- a/lib/fastly-rails/engine.rb
+++ b/lib/fastly-rails/engine.rb
@@ -2,6 +2,7 @@ require 'fastly-rails/active_record/surrogate_key'
 require 'fastly-rails/mongoid/surrogate_key'
 require 'fastly-rails/action_controller/cache_control_headers'
 require 'fastly-rails/action_controller/surrogate_key_headers'
+require 'fastly-rails/rack/remove_set_cookie_header'
 
 module FastlyRails
   class Engine < ::Rails::Engine

--- a/lib/fastly-rails/rack/remove_set_cookie_header.rb
+++ b/lib/fastly-rails/rack/remove_set_cookie_header.rb
@@ -1,0 +1,19 @@
+module FastlyRails
+  module Rack
+    class RemoveSetCookieHeader
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, response = @app.call(env)
+
+        if headers["Surrogate-Control"] || headers["Surrogate-Key"]
+          headers.delete("Set-Cookie")
+        end
+
+        [status, headers, response]
+      end
+    end
+  end
+end

--- a/test/dummy/test/lib/remove_set_cookie_header_test.rb
+++ b/test/dummy/test/lib/remove_set_cookie_header_test.rb
@@ -1,0 +1,43 @@
+describe FastlyRails::Rack::RemoveSetCookieHeader do
+  it "removes 'set-cookie' header if 'surrogate-control' header present" do
+    headers = { "Surrogate-Control" => "test", "Set-Cookie" => "NOOO" }
+
+    app = Rack::Builder.new do
+      use FastlyRails::Rack::RemoveSetCookieHeader
+      run lambda { |env| Rack::Response.new("", 200, headers).finish }
+    end
+
+    env = Rack::MockRequest.env_for('/')
+    response = Rack::MockResponse.new(*app.call(env))
+
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  it "removes 'set-cookie' header if 'surrogate-key' header present" do
+    headers = { "Surrogate-Key" => "test", "Set-Cookie" => "NOOO" }
+
+    app = Rack::Builder.new do
+      use FastlyRails::Rack::RemoveSetCookieHeader
+      run lambda { |env| Rack::Response.new("", 200, headers).finish }
+    end
+
+    env = Rack::MockRequest.env_for('/')
+    response = Rack::MockResponse.new(*app.call(env))
+
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  it "keeps 'set-cookie' if no 'surrogate-control' or 'surrogate-key'" do
+    headers = { "Set-Cookie" => "yes!!" }
+
+    app = Rack::Builder.new do
+      use FastlyRails::Rack::RemoveSetCookieHeader
+      run lambda { |env| Rack::Response.new("", 200, headers).finish }
+    end
+
+    env = Rack::MockRequest.env_for('/')
+    response = Rack::MockResponse.new(*app.call(env))
+
+    assert_equal response.headers['Set-Cookie'], "yes!!"
+  end
+end


### PR DESCRIPTION
- In my case, Clearance middleware was adding `Set-Cookie` to every request
- This occured after `set_cache_control_headers` was called, whether it was a
  `before_filter` or `after_filter`
- Optional middleware looks for `Surrogate-Control` header so it only removes
  `Set-Cookie` for endpoints not being cached by Fastly
