### PR TITLE
Fix purge method receiver regression

### DIFF
--- a/lib/fastly-rails/active_record/surrogate_key.rb
+++ b/lib/fastly-rails/active_record/surrogate_key.rb
@@ -9,7 +9,7 @@ module FastlyRails
       module ClassMethods
 
         def purge_all
-          FastlyRails::Client.purge_by_key(table_key)
+          FastlyRails.client.purge_by_key(table_key)
         end
 
         def table_key
@@ -30,7 +30,7 @@ module FastlyRails
       end
 
       def purge
-        FastlyRails::Client.purge_by_key(record_key)
+        FastlyRails.client.purge_by_key(record_key)
       end
 
       def purge_all

--- a/lib/fastly-rails/mongoid/surrogate_key.rb
+++ b/lib/fastly-rails/mongoid/surrogate_key.rb
@@ -7,7 +7,7 @@ module FastlyRails
       module ClassMethods
 
         def purge_all
-          FastlyRails::Client.purge_by_key(table_key)
+          FastlyRails.client.purge_by_key(table_key)
         end
 
         def table_key
@@ -28,7 +28,7 @@ module FastlyRails
       end
 
       def purge
-        FastlyRails::Client.purge_by_key(record_key)
+        FastlyRails.client.purge_by_key(record_key)
       end
 
       def purge_all


### PR DESCRIPTION
Hey folks,
#27 introduced a regression by erroneously sending the `#purge_by_key` method as class-level to `FastlyRails::Client`. In reality, the spec provided with this change was actually testing sending them to an instance of the class.

This fixes the receiver in both ActiveRecord and Mongoid. Regression originally discovered via spec suite at `fastly/spree_fastly`. Only exists in 0.1.6 and not 0.1.5, obviously. 

Ran the test suite, it passes. But having said that, it was testing the correct receiver to begin with. 
