### PR TITLE
Allow Fastly headers and purges to be disabled globally

### DIFF
--- a/lib/fastly-rails/action_controller/cache_control_headers.rb
+++ b/lib/fastly-rails/action_controller/cache_control_headers.rb
@@ -7,12 +7,14 @@ module FastlyRails
     # Defaults are:
     #  Cache-Control: 'public, no-cache'
     #  Surrogate-Control: 'max-age: 30 days
-    # custom config example: 
+    # custom config example:
     #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: blah'}
     def set_cache_control_headers(max_age = FastlyRails.configuration.max_age, opts = {})
-      request.session_options[:skip] = true    # no cookies
-      response.headers['Cache-Control'] = opts[:cache_control] || "public, no-cache"
-      response.headers['Surrogate-Control'] = opts[:surrogate_control] || "max-age=#{max_age}"
+      unless ENV["FASTLY_CACHE_DISABLED"].present?
+        request.session_options[:skip] = true    # no cookies
+        response.headers['Cache-Control'] = opts[:cache_control] || "public, no-cache"
+        response.headers['Surrogate-Control'] = opts[:surrogate_control] || "max-age=#{max_age}"
+      end
     end
 
 

--- a/lib/fastly-rails/action_controller/surrogate_key_headers.rb
+++ b/lib/fastly-rails/action_controller/surrogate_key_headers.rb
@@ -4,8 +4,10 @@ module FastlyRails
     # Sets Surrogate-Key HTTP header with one or more keys
     # strips session data from the request
     def set_surrogate_key_header(*surrogate_keys)
-      request.session_options[:skip] = true  # No Set-Cookie
-      response.headers['Surrogate-Key'] = surrogate_keys.join(' ')
+      unless ENV["FASTLY_CACHE_DISABLED"].present?
+        request.session_options[:skip] = true  # No Set-Cookie
+        response.headers['Surrogate-Key'] = surrogate_keys.join(' ')
+      end
     end
   end
 end

--- a/lib/fastly-rails/active_record/surrogate_key.rb
+++ b/lib/fastly-rails/active_record/surrogate_key.rb
@@ -9,7 +9,9 @@ module FastlyRails
       module ClassMethods
 
         def purge_all
-          FastlyRails.client.purge_by_key(table_key)
+          unless ENV["FASTLY_CACHE_DISABLED"].present?
+            FastlyRails.client.purge_by_key(table_key)
+          end
         end
 
         def table_key
@@ -30,7 +32,9 @@ module FastlyRails
       end
 
       def purge
-        FastlyRails.client.purge_by_key(record_key)
+        unless ENV["FASTLY_CACHE_DISABLED"].present?
+          FastlyRails.client.purge_by_key(record_key)
+        end
       end
 
       def purge_all

--- a/lib/fastly-rails/client.rb
+++ b/lib/fastly-rails/client.rb
@@ -8,8 +8,10 @@ module FastlyRails
     end
 
     def purge_by_key(key)
-      client.require_key!
-      client.post purge_url(key)
+      unless ENV["FASTLY_CACHE_DISABLED"].present?
+        client.require_key!
+        client.post purge_url(key)
+      end
     end
 
     def purge_url(key)

--- a/lib/fastly-rails/rack/remove_set_cookie_header.rb
+++ b/lib/fastly-rails/rack/remove_set_cookie_header.rb
@@ -8,8 +8,10 @@ module FastlyRails
       def call(env)
         status, headers, response = @app.call(env)
 
-        if headers["Surrogate-Control"] || headers["Surrogate-Key"]
-          headers.delete("Set-Cookie")
+        unless ENV["FASTLY_CACHE_DISABLED"].present?
+          if headers["Surrogate-Control"] || headers["Surrogate-Key"]
+            headers.delete("Set-Cookie")
+          end
         end
 
         [status, headers, response]

--- a/test/dummy/test/controllers/books_controller_test.rb
+++ b/test/dummy/test/controllers/books_controller_test.rb
@@ -6,8 +6,7 @@ class BooksControllerTest < ActionController::TestCase
     WebMock.stub_request(:any, /.*/).
     to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
     @no_of_books = 5
     create_list :book, @no_of_books

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,8 +31,7 @@ class Minitest::Spec
     stub_request(:any, "https://api.fastly.com/login").
       to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
     stub_request(:post, /https:\/\/api.fastly.com\/service\/.*\/purge\/.*/)
     .to_return(
@@ -59,12 +58,9 @@ class ActionDispatch::IntegrationTest
     stub_request(:any, /.*/).
     to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
 
   end
 
 end
-
-


### PR DESCRIPTION
Useful for tests and development modes