### PR TITLE
Properly tell Rails that a request is (or is not) SSL

### DIFF
--- a/lib/fastly-rails/rack/set_x_forwarded_headers.rb
+++ b/lib/fastly-rails/rack/set_x_forwarded_headers.rb
@@ -1,0 +1,44 @@
+module FastlyRails
+  module Rack
+    # Set the X-Forwarded-Proto header to reflect
+    # the browser/Fastly connection.
+    #
+    # Useful for apps hosted on Heroku, where the X-Forwarded
+    # headers are set by the Heroku router to represent only the
+    # direct connection from Fastly's proxy server to Heroku.
+    #
+    # Example usage:
+    # ```
+    # config.middleware.insert_after(Rack::MethodOverride, FastlyRails::Rack::SetXForwardedHeaders)
+    # ```
+    class SetXForwardedHeaders
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if is_behind_fastly?(env)
+          if is_ssl?(env)
+            env["HTTPS"] = "on"
+            env["HTTP_X_FORWARDED_PROTO"] = "https"
+          else
+            env["HTTP_X_FORWARDED_PROTO"] = "http"
+          end
+          # Disambiguate
+          env.delete("HTTP_X_FORWARDED_PORT")
+          env.delete("HTTP_X_FORWARDED_SSL")
+          env.delete("HTTP_X_FORWARDED_SCHEME")
+        end
+        @app.call(env)
+      end
+
+      def is_behind_fastly?(env)
+        env["HTTP_FASTLY_CLIENT_IP"].present?
+      end
+
+      def is_ssl?(env)
+        env["HTTP_FASTLY_SSL"].present?
+      end
+    end
+  end
+end

--- a/test/fastly-rails/set_x_forwarded_headers_test.rb
+++ b/test/fastly-rails/set_x_forwarded_headers_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+require 'fastly-rails/rack/set_x_forwarded_headers'
+
+describe FastlyRails::Rack::SetXForwardedHeaders do
+  let(:ip) { Faker::Internet.ip_v4_address }
+  let(:middleware) { FastlyRails::Rack::SetXForwardedHeaders.new(app) }
+
+  describe 'without fastly' do
+    let(:headers) { {"HTTP_X_FORWARDED_PROTO" => "ftp"} }
+    let(:app) {
+      Proc.new { |env|
+        assert_nil env['HTTPS'], "Env var should not exist"
+        assert_equal "ftp", env['HTTP_X_FORWARDED_PROTO'], "Header should not have been modifed"
+        [200, {'Content-Type' => 'text/html'}, ["hello"]]
+      }
+    }
+    it 'should not change the env' do
+      middleware.call(headers)
+    end
+  end
+
+  describe 'with fastly' do
+    describe 'without ssl header' do
+      let(:headers) { {"HTTP_FASTLY_CLIENT_IP" => ip} }
+      let(:app) {
+        Proc.new { |env|
+          assert_nil env['HTTPS'], "Env var should not exist"
+          assert_equal "http", env['HTTP_X_FORWARDED_PROTO']
+          [200, {'Content-Type' => 'text/html'}, ["hello"]]
+        }
+      }
+      it 'should modify the env properly' do
+        middleware.call(headers)
+      end
+    end
+    describe 'with ssl header' do
+      let(:headers) { {"HTTP_FASTLY_CLIENT_IP" => ip, "HTTP_FASTLY_SSL" => "1"} }
+      let(:app) {
+        Proc.new { |env|
+          assert_equal "on", env['HTTPS']
+          assert_equal "https", env['HTTP_X_FORWARDED_PROTO']
+          [200, {'Content-Type' => 'text/html'}, ["hello"]]
+        }
+      }
+      it 'should modify the env properly' do
+        middleware.call(headers)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When hosting on Heroku, the Heroku router sets `X-Forwarded-Proto` to the protocol used by the immediate connection (from Fastly). If it's https, then Rails will never know if a browser connects insecurely. If it's http, then Rails will think every connection is insecure, even when the browser connection to fastly is over https.

This Rack middleware fixes that by setting the proper headers based on the `Fastly-SSL` header. The fixes are only applied if the connection appears to be from Fastly.
- set HTTPS=on
- set X-Forwarded-Proto=https
- remove other ambiguous headers
