### PR TITLE
bump Fastly to 1.2.0

### DIFF
--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
-  s.add_dependency 'fastly', '~> 1.1.4'
+  s.add_dependency 'fastly', '~> 1.2.0'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "database_cleaner"

--- a/test/dummy/test/controllers/books_controller_test.rb
+++ b/test/dummy/test/controllers/books_controller_test.rb
@@ -6,8 +6,7 @@ class BooksControllerTest < ActionController::TestCase
     WebMock.stub_request(:any, /.*/).
     to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
     @no_of_books = 5
     create_list :book, @no_of_books

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,9 +30,9 @@ class Minitest::Spec
   before :each do
     stub_request(:any, "https://api.fastly.com/login").
       to_return(
-        :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        status: 200,
+        body: "{}",
+        headers: {'Set-Cookie' => ""}
     )
     stub_request(:post, /https:\/\/api.fastly.com\/service\/.*\/purge\/.*/)
     .to_return(
@@ -59,12 +59,9 @@ class ActionDispatch::IntegrationTest
     stub_request(:any, /.*/).
     to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
 
   end
 
 end
-
-


### PR DESCRIPTION
Fastly Gem switch from Curb to Net::HTTP which caused some minor test breakage