### PR TITLE
Rename service_id to fastly_service_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.3.0 / 2015-03-12
+  * Potentially Breaking Change: rename `service_id` methods to `fastly_service_identifier` in both the active_record and mongoid mix-ins (in response to https://github.com/fastly/fastly-rails/issues/36)
+
 ### 0.2.0 / 2014-10-02
   * Require API key for purge requests
   * Bumps fastly-ruby gem dep to 1.1.4

--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ We have left these out intentially, as they could potentially cause issues when 
 
 ### Service id
 
-One thing to note is that currently we expect a service_id to be defined in your FastlyRails.configuration.  However, we've added localized methods so that your models can override your global service_id, if you needed to operate on more than one for any reason.
+One thing to note is that currently we expect a service_id to be defined in your FastlyRails.configuration.  However, we've added localized methods so that your models can override your global service_id, if you needed to operate on more than one for any reason.  NOTE: As of 0.3.0, we've renamed the class-level and instance-level `service_id` methods to `fastly_service_identifier` in the active_record and mongoid mix-ins.  See the CHANGELOG for a link to the Github issue.
 
-Currently, this would require you to basically redefine `service_id` on the class level of your model:
+Currently, this would require you to basically redefine `fastly_service_identifier` on the class level of your model:
 
 ````ruby
 class Book < ActiveRecord::Base
-  def self.service_id
+  def self.fastly_service_identifier
     'MYSERVICEID'
   end
 end

--- a/lib/fastly-rails/active_record/surrogate_key.rb
+++ b/lib/fastly-rails/active_record/surrogate_key.rb
@@ -16,7 +16,7 @@ module FastlyRails
           table_name
         end
 
-        def service_id
+        def fastly_service_identifier
           FastlyRails.service_id
         end
       end
@@ -37,8 +37,8 @@ module FastlyRails
         self.class.purge_all
       end
 
-      def service_id
-        self.class.service_id
+      def fastly_service_identifier
+        self.class.fastly_service_identifier
       end
     end
   end

--- a/lib/fastly-rails/mongoid/surrogate_key.rb
+++ b/lib/fastly-rails/mongoid/surrogate_key.rb
@@ -14,7 +14,7 @@ module FastlyRails
           collection_name
         end
 
-        def service_id
+        def fastly_service_identifier
           FastlyRails.service_id
         end
       end
@@ -35,8 +35,8 @@ module FastlyRails
         self.class.purge_all
       end
 
-      def service_id
-        self.class.service_id
+      def fastly_service_identifier
+        self.class.fastly_service_identifier
       end
 
     end

--- a/lib/fastly-rails/version.rb
+++ b/lib/fastly-rails/version.rb
@@ -1,3 +1,3 @@
 module FastlyRails
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/dummy/db/migrate/20150312044151_add_service_id_to_books.rb
+++ b/test/dummy/db/migrate/20150312044151_add_service_id_to_books.rb
@@ -1,0 +1,5 @@
+class AddServiceIdToBooks < ActiveRecord::Migration
+  def change
+    add_column :books, :service_id, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,12 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140407202136) do
+ActiveRecord::Schema.define(version: 20150312044151) do
 
   create_table "books", force: true do |t|
     t.text     "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "service_id"
   end
 
 end

--- a/test/dummy/test/controllers/books_controller_test.rb
+++ b/test/dummy/test/controllers/books_controller_test.rb
@@ -6,8 +6,7 @@ class BooksControllerTest < ActionController::TestCase
     WebMock.stub_request(:any, /.*/).
     to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
     @no_of_books = 5
     create_list :book, @no_of_books

--- a/test/dummy/test/factories/books.rb
+++ b/test/dummy/test/factories/books.rb
@@ -3,6 +3,6 @@
 FactoryGirl.define do
   factory :book do
     name  { Faker::Movie.title }
-    service_id 'some-service-id'
+    service_id 'asdf'
   end
 end

--- a/test/dummy/test/factories/books.rb
+++ b/test/dummy/test/factories/books.rb
@@ -3,5 +3,6 @@
 FactoryGirl.define do
   factory :book do
     name  { Faker::Movie.title }
+    service_id 'some-service-id'
   end
 end

--- a/test/dummy/test/models/book_test.rb
+++ b/test/dummy/test/models/book_test.rb
@@ -47,7 +47,7 @@ describe Book do
       assert_respond_to Book, :fastly_service_identifier
     end
 
-    it 'it is an instance method' do
+    it 'is an instance method' do
       assert_respond_to book, :fastly_service_identifier
     end
 

--- a/test/dummy/test/models/book_test.rb
+++ b/test/dummy/test/models/book_test.rb
@@ -38,21 +38,21 @@ describe Book do
     assert_equal Book.table_key, book.table_key
   end
 
-  describe 'service_id' do
+  describe 'fastly_service_identifier' do
     before do
-      FastlyRails.configuration.service_id = 'someserviceid'
+      FastlyRails.configuration.service_id = 'some-service-id'
     end
 
-    it 'should have class.service_id' do
-      assert_respond_to Book, :service_id
+    it 'is a class method' do
+      assert_respond_to Book, :fastly_service_identifier
     end
 
-    it 'should have instance.service_id' do
-      assert_respond_to book, :service_id
+    it 'it is an instance method' do
+      assert_respond_to book, :fastly_service_identifier
     end
 
-    it 'should be class.service_id == instance.service_id' do
-      assert_equal Book.service_id, book.service_id
+    it 'is true that class.fastly_service_identifier == instance.fastly_service_identifier' do
+      assert_equal Book.fastly_service_identifier, book.fastly_service_identifier
     end
 
     after do

--- a/test/dummy/test/models/book_test.rb
+++ b/test/dummy/test/models/book_test.rb
@@ -55,6 +55,10 @@ describe Book do
       assert_equal Book.fastly_service_identifier, book.fastly_service_identifier
     end
 
+    it 'does not equal the value of `service_id` on the model' do
+      refute_equal book.service_id, book.fastly_service_identifier
+    end
+
     after do
       FastlyRails.configuration.service_id = nil
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,8 +31,7 @@ class Minitest::Spec
     stub_request(:any, "https://api.fastly.com/login").
       to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
     stub_request(:post, /https:\/\/api.fastly.com\/service\/.*\/purge\/.*/)
     .to_return(
@@ -59,8 +58,7 @@ class ActionDispatch::IntegrationTest
     stub_request(:any, /.*/).
     to_return(
         :status   => 200,
-        :body     => "{}",
-        :message  => "{}"
+        :body     => "{}"
     )
 
   end


### PR DESCRIPTION
Fix #36.

In order to allow applications to have `service_id` as a database column, we are renaming the mix-in methods for active_record and mongoid to `fastly_service_identifier`.  This change did not require to rename the FastlyRails level service_id attributes; as those do not cause collision.

Tests have been updated.