### PR TITLE
add link to docs for service ids and api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ gem 'fastly-rails'
 
 ## Configuration
 
+For information about how to find your Fastly API Key or a Fastly Service ID, refer to our [documentation](https://docs.fastly.com/guides/faqs/where-can-i-find-my-service-id-customer-id-or-api-key).
+
 Create an initializer for Fastly configuration
 
 ````ruby


### PR DESCRIPTION
Added per request by @monfresh here: https://github.com/fastly/fastly-rails/issues/36#issuecomment-80745623