### PR TITLE
Update fastly-ruby gem to 1.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ script: 'bundle exec rake test:all'
 rvm:
   - 2.1.1
   - 1.9.3
+before_install:
+  - gem install bundler -v 1.11.2

--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
-  s.add_dependency 'fastly', '~> 1.1.4'
+  s.add_dependency 'fastly', '~> 1.2.1'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "database_cleaner"

--- a/test/fastly-rails/client_test.rb
+++ b/test/fastly-rails/client_test.rb
@@ -4,7 +4,7 @@ describe FastlyRails::Client do
 
   let(:client) do
     FastlyRails::Client.new(
-      :api_key => 'KEY', :user => 'USER', :password => 'PASS'
+      :api_key => 'KEY'
     )
   end
 
@@ -51,12 +51,20 @@ describe FastlyRails::Client do
     end
 
     it 'should be authed' do
-      assert_equal true, client.fully_authed?
-
-      client.client.user = nil
-      client.client.password = nil
-      assert_equal false, client.fully_authed?
       assert_equal true, client.authed?
+      assert_equal false, client.fully_authed?
+    end
+
+    describe 'when username and password are supplied' do
+      before do
+        client.client.user = 'USER'
+        client.client.password = 'PASS'
+      end
+
+      it 'should be fully authed' do
+        assert_equal true, client.authed?
+        assert_equal true, client.fully_authed?
+      end
     end
   end
 


### PR DESCRIPTION
This new version removes the transitive dependency on the `curb` gem, instead using basic Net::HTTP calls under the hood