### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -14,8 +14,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails"
+  s.add_dependency "railties"
   s.add_dependency 'fastly', '~> 1.2.1'
+
+  s.add_runtime_dependency('mime-types', ['>= 1.16', '< 3'])
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "database_cleaner"
@@ -24,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-spec-rails"
   s.add_development_dependency "appraisal"
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rails'
 end


### PR DESCRIPTION
...so that people who are not using e.g. `activerecord` don't get it as an added dependency when including `fastly-rails`.