### PR TITLE
bumping fastly dependency to 1.3.0

### DIFF
--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "railties"
-  s.add_dependency 'fastly', '~> 1.2.1'
+  s.add_dependency 'fastly', '~> 1.3.0'
 
   s.add_runtime_dependency('mime-types', ['>= 1.16', '< 3'])
 

--- a/lib/fastly-rails/client.rb
+++ b/lib/fastly-rails/client.rb
@@ -1,4 +1,5 @@
 require 'fastly'
+require 'uri'
 
 module FastlyRails
   # A simple wrapper around the fastly-ruby client.
@@ -13,7 +14,7 @@ module FastlyRails
     end
 
     def purge_url(key)
-      "/service/#{FastlyRails.service_id}/purge/#{key}"
+      "/service/#{FastlyRails.service_id}/purge/#{URI.escape(key)}"
     end
   end
 end


### PR DESCRIPTION
This fixes purging when keys have spaces on them as per https://github.com/fastly/fastly-ruby/commit/e6e613bc962396c78c4cc957c8cfe26ea796022a