### PR TITLE
Adds soft purging from fastly-ruby client

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ end
 
 ### Purges
 
-Any object that inherits from ActiveRecord will have `purge_all` and `table_key` class methods available as well as `purge` and `purge_all` instance methods.
+Any object that inherits from ActiveRecord will have `purge_all`, `soft_purge_all`, and `table_key` class methods available as well as `purge`, `soft_purge`, `purge_all`, and `soft_purge_all` instance methods.
 
 Example usage is show below.
 

--- a/lib/fastly-rails/active_record/surrogate_key.rb
+++ b/lib/fastly-rails/active_record/surrogate_key.rb
@@ -12,6 +12,10 @@ module FastlyRails
           FastlyRails.purge_by_key(table_key)
         end
 
+        def soft_purge_all
+          FastlyRails.purge_by_key(table_key, true)
+        end
+
         def table_key
           table_name
         end
@@ -33,8 +37,16 @@ module FastlyRails
         FastlyRails.purge_by_key(record_key)
       end
 
+      def soft_purge
+        FastlyRails.purge_by_key(record_key, true)
+      end
+
       def purge_all
         self.class.purge_all
+      end
+
+      def soft_purge_all
+        self.class.soft_purge_all
       end
 
       def fastly_service_identifier

--- a/lib/fastly-rails/version.rb
+++ b/lib/fastly-rails/version.rb
@@ -1,3 +1,3 @@
 module FastlyRails
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/test/dummy/test/models/book_test.rb
+++ b/test/dummy/test/models/book_test.rb
@@ -12,7 +12,7 @@ describe Book do
 
   it "should have Fastly::SurrogateKey instance methods" do
 
-    [:record_key, :table_key, :purge, :purge_all].each do |method|
+    [:record_key, :table_key, :purge, :purge_all, :soft_purge, :soft_purge_all].each do |method|
       assert_respond_to book, method
     end
 
@@ -20,7 +20,7 @@ describe Book do
 
   it "should have Fastly::SurrogateKey class methods" do
 
-    [:table_key, :purge_all].each do |method|
+    [:table_key, :purge_all, :soft_purge_all].each do |method|
       assert_respond_to Book, method
     end
 

--- a/test/fastly-rails_test.rb
+++ b/test/fastly-rails_test.rb
@@ -69,6 +69,16 @@ describe FastlyRails do
       end
     end
 
+    it 'allows soft purging' do
+      FastlyRails.stub(:client, client) do
+        FastlyRails.stub(:purging_enabled?, true) do
+          client.expect(:purge_by_key, nil, [key, true])
+          FastlyRails.purge_by_key(key, true)
+          client.verify
+        end
+      end
+    end
+
     it 'does nothing when purging is disabled' do
       configuration.purging_enabled = false
       FastlyRails.stub(:client, client) do


### PR DESCRIPTION
* Includes `soft_purge`, `soft_purge_all` class/instance methods within ActiveRecord. Useful for callbacks, or calling on an instance of an ActiveRecord model

Concerns:
* Do we want to include same functionality for `Mongoid`?
* This all hinges on the fact that the [client method](https://github.com/fastly/fastly-ruby/blob/ca7197e8e592549a6d16a129b11f75828e7f4add/README.md#L147) is well tested
* Ideally, I'd rather use keyword args, but that's not very well backwards compatible with old rubies