### PR TITLE
chore: remove mime-types dependency

### DIFF
--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency "railties", '> 2', '< 6'
   s.add_dependency 'fastly', '~> 1.6'
 
-  s.add_runtime_dependency('mime-types', ['>= 1.16', '< 3'])
-
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "factory_girl_rails"


### PR DESCRIPTION
This does not need to be explicitly set.  Let rubygems resolve the correct version.

Closes #53