### PR TITLE
test: use WebMock to disable live connections

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,8 @@ class Minitest::Spec
       body: "{\"status\":\"ok\"}"
     )
 
+    WebMock.disable_net_connect!
+
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION
There are some transient test failures due to purge requests to matching the intended stubs.  Disabling net connections will help diagnose this issue but raising when a request is not matching.