### PR TITLE
Add soft purge methods to Mongoid adapter

### DIFF
--- a/lib/fastly-rails/mongoid/surrogate_key.rb
+++ b/lib/fastly-rails/mongoid/surrogate_key.rb
@@ -10,6 +10,10 @@ module FastlyRails
           FastlyRails.purge_by_key(table_key)
         end
 
+        def soft_purge_all
+          FastlyRails.purge_by_key(table_key, true)
+        end
+
         def table_key
           collection_name
         end
@@ -31,8 +35,16 @@ module FastlyRails
         FastlyRails.purge_by_key(record_key)
       end
 
+      def soft_purge
+        FastlyRails.purge_by_key(record_key, true)
+      end
+
       def purge_all
         self.class.purge_all
+      end
+
+      def soft_purge_all
+        self.class.soft_purge_all
       end
 
       def fastly_service_identifier


### PR DESCRIPTION
Adds `soft_purge` and friends so that the Mongoid adapter is in alignment with its ActiveRecord counterpart. Your test suite doesn't have any Mongoid coverage and adding it seemed like an over-complication, but let me know if it's critical to this PR.