### PR TITLE
Fix example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ end
 To simplify controller methods, you could use ActiveRecord callbacks. e.g.
 
 ````ruby
-class Book < ActiveRecord
+class Book < ActiveRecord::Base
   after_create :purge_all
   after_save :purge
   after_destroy :purge, :purge_all


### PR DESCRIPTION
`ActiveRecord` is a module. So it is not interited as a class.
Instead, `ActiveRecord::Base` (Rails < 5 way) or `ApplicationRecord` (Rails >= 5 way) is correct.