### PR TITLE
Update fastly dependency

### DIFF
--- a/fastly-rails.gemspec
+++ b/fastly-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "railties", '> 2', '< 6'
-  s.add_dependency 'fastly', '~> 1.6'
+  s.add_dependency 'fastly', '~> 2.0'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "database_cleaner"


### PR DESCRIPTION
fastly-ruby v2.0.0 has been released, but fastly-rails is locked at < 2, due to pessimistic version control.  This PR updates the dependency.