### PR TITLE
Add purge by url method

### DIFF
--- a/lib/fastly-rails.rb
+++ b/lib/fastly-rails.rb
@@ -26,6 +26,10 @@ module FastlyRails
     client.purge_by_key(*args) if purging_enabled?
   end
 
+  def self.purge_by_url(url, soft = false)
+    client.purge(url, soft) if purging_enabled?
+  end
+
   def self.client
     raise NoAPIKeyProvidedError unless configuration.authenticatable?
 

--- a/test/fastly-rails_test.rb
+++ b/test/fastly-rails_test.rb
@@ -94,7 +94,7 @@ describe FastlyRails do
     it 'delegates to the client when purging is enabled' do
       FastlyRails.stub(:client, client) do
         FastlyRails.stub(:purging_enabled?, true) do
-          client.expect(:purge, nil, [url])
+          client.expect(:purge, nil, [url, false])
           FastlyRails.purge_by_url(url)
           client.verify
         end

--- a/test/fastly-rails_test.rb
+++ b/test/fastly-rails_test.rb
@@ -94,7 +94,7 @@ describe FastlyRails do
     it 'delegates to the client when purging is enabled' do
       FastlyRails.stub(:client, client) do
         FastlyRails.stub(:purging_enabled?, true) do
-          client.expect(:purge_by_url, nil, [url])
+          client.expect(:purge, nil, [url])
           FastlyRails.purge_by_url(url)
           client.verify
         end
@@ -104,7 +104,7 @@ describe FastlyRails do
     it 'allows soft purging' do
       FastlyRails.stub(:client, client) do
         FastlyRails.stub(:purging_enabled?, true) do
-          client.expect(:purge_by_url, nil, [url, true])
+          client.expect(:purge, nil, [url, true])
           FastlyRails.purge_by_url(url, true)
           client.verify
         end

--- a/test/fastly-rails_test.rb
+++ b/test/fastly-rails_test.rb
@@ -86,4 +86,36 @@ describe FastlyRails do
       end
     end
   end
+
+  describe 'purge_by_url' do
+    let(:client) {  MiniTest::Mock.new }
+    let(:url) { "http://test.com" }
+
+    it 'delegates to the client when purging is enabled' do
+      FastlyRails.stub(:client, client) do
+        FastlyRails.stub(:purging_enabled?, true) do
+          client.expect(:purge_by_url, nil, [url])
+          FastlyRails.purge_by_url(url)
+          client.verify
+        end
+      end
+    end
+
+    it 'allows soft purging' do
+      FastlyRails.stub(:client, client) do
+        FastlyRails.stub(:purging_enabled?, true) do
+          client.expect(:purge_by_url, nil, [url, true])
+          FastlyRails.purge_by_url(url, true)
+          client.verify
+        end
+      end
+    end
+
+    it 'does nothing when purging is disabled' do
+      configuration.purging_enabled = false
+      FastlyRails.stub(:client, client) do
+        FastlyRails.purge_by_url(url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We use `Fastly#purge` or `Fastly::Client#purge` to purge by url. So, add `purge_by_url` method in FastlyRails.